### PR TITLE
Remove deprecated createUseComponent hook

### DIFF
--- a/lib/get-component-using-template.ts
+++ b/lib/get-component-using-template.ts
@@ -20,38 +20,17 @@ export const getComponentUsingTemplate = ({
 }: ComponentTemplateParams) => {
   const footprintTsx = generateFootprintTsx(circuitJson)
   return `
-import { createUseComponent } from "@tscircuit/core"
-import type { CommonLayoutProps } from "@tscircuit/props"
-
-const pinLabels = ${JSON.stringify(pinLabels, null, "  ")} as const
-
-interface Props extends CommonLayoutProps {
-  name: string
-}
-
-export const ${componentName} = (props: Props) => {
-  return (
-    <chip
-      {...props}
-      ${
-        objUrl
-          ? `cadModel={{
-        objUrl: "${objUrl}",
-        rotationOffset: { x: 0, y: 0, z: 0 },
-        positionOffset: { x: 0, y: 0, z: 0 },
-      }}`
-          : ""
-      }
-      ${pinLabels ? `pinLabels={${JSON.stringify(pinLabels, null, "  ")}}` : ""}
-      ${supplierPartNumbers ? `supplierPartNumbers={${JSON.stringify(supplierPartNumbers, null, "  ")}}` : ""}
-      ${manufacturerPartNumber ? `manufacturerPartNumber="${manufacturerPartNumber}"` : ""}
-      footprint={${footprintTsx}}
-    />
-  )
-}
-
-export const use${componentName} = createUseComponent(${componentName}, pinLabels)
-
+import { type ChipProps } from "tscircuit"
+${pinLabels ? `const pinLabels = ${JSON.stringify(pinLabels, null, "  ")} as const\n` : ""}export const ${componentName} = (props: ChipProps${pinLabels ? `<typeof pinLabels>` : ""}) => (
+  <chip
+    footprint={${footprintTsx}}
+    ${pinLabels ? "pinLabels={pinLabels}" : ""}
+    ${objUrl ? `cadModel={{\n        objUrl: \"${objUrl}\",\n        rotationOffset: { x: 0, y: 0, z: 0 },\n        positionOffset: { x: 0, y: 0, z: 0 },\n      }}` : ""}
+    ${supplierPartNumbers ? `supplierPartNumbers={${JSON.stringify(supplierPartNumbers, null, "  ")}}` : ""}
+    ${manufacturerPartNumber ? `manufacturerPartNumber=\"${manufacturerPartNumber}\"` : ""}
+    {...props}
+  />
+)
 `
     .replace(/\n\s*\n/g, "\n")
     .trim()

--- a/tests/cli/cli-circuit-json-to-tsx.test.tsx
+++ b/tests/cli/cli-circuit-json-to-tsx.test.tsx
@@ -18,25 +18,17 @@ test("should convert sample circuit.json to TSX", async () => {
   // Verify output file content
   const output = await readFile(outputPath, "utf-8")
   expect(output).toMatchInlineSnapshot(`
-"import { createUseComponent } from "@tscircuit/core"
-import type { CommonLayoutProps } from "@tscircuit/props"
-const pinLabels = undefined as const
-interface Props extends CommonLayoutProps {
-  name: string
-}
-export const Circuit = (props: Props) => {
-  return (
-    <chip
-      {...props}
-      footprint={<footprint>
-        <smtpad portHints={["1","left"]} pcbX="-0.5mm" pcbY="0mm" width="0.6000000000000001mm" height="0.6000000000000001mm" shape="rect" />
-<smtpad portHints={["2","right"]} pcbX="0.5mm" pcbY="0mm" width="0.6000000000000001mm" height="0.6000000000000001mm" shape="rect" />
-      </footprint>}
-    />
-  )
-}
-export const useCircuit = createUseComponent(Circuit, pinLabels)"
-`)
+    "import { type ChipProps } from "tscircuit"
+    export const Circuit = (props: ChipProps) => (
+      <chip
+        footprint={<footprint>
+            <smtpad portHints={["1","left"]} pcbX="-0.5mm" pcbY="0mm" width="0.6000000000000001mm" height="0.6000000000000001mm" shape="rect" />
+    <smtpad portHints={["2","right"]} pcbX="0.5mm" pcbY="0mm" width="0.6000000000000001mm" height="0.6000000000000001mm" shape="rect" />
+          </footprint>}
+        {...props}
+      />
+    )"
+  `)
 })
 
 test("should require output path", async () => {

--- a/tests/test1-basic-circuit.test.tsx
+++ b/tests/test1-basic-circuit.test.tsx
@@ -1,6 +1,7 @@
 import { test, expect } from "bun:test"
 import { convertCircuitJsonToTscircuit } from "lib/index"
-import { Circuit } from "@tscircuit/core"
+import { readFile } from "node:fs/promises"
+import { join } from "node:path"
 
 declare module "bun:test" {
   interface Matchers<T = unknown> {
@@ -9,38 +10,27 @@ declare module "bun:test" {
 }
 
 test("test1 basic circuit", async () => {
-  const circuit = new Circuit()
-
-  circuit.add(
-    <group subcircuit>
-      <resistor name="R1" resistance="1k" footprint="0402" />
-    </group>,
+  const circuitJson = JSON.parse(
+    await readFile(
+      join(__dirname, "../assets/input-circuit-json.json"),
+      "utf-8",
+    ),
   )
-
-  const circuitJson = circuit.getCircuitJson()
 
   const tscircuit = convertCircuitJsonToTscircuit(circuitJson, {
     componentName: "MyResistor",
   })
 
   expect(tscircuit).toMatchInlineSnapshot(`
-"import { createUseComponent } from "@tscircuit/core"
-import type { CommonLayoutProps } from "@tscircuit/props"
-const pinLabels = undefined as const
-interface Props extends CommonLayoutProps {
-  name: string
-}
-export const MyResistor = (props: Props) => {
-  return (
-    <chip
-      {...props}
-      footprint={<footprint>
-        <smtpad portHints={["1","left"]} pcbX="-0.5mm" pcbY="0mm" width="0.6000000000000001mm" height="0.6000000000000001mm" shape="rect" />
-<smtpad portHints={["2","right"]} pcbX="0.5mm" pcbY="0mm" width="0.6000000000000001mm" height="0.6000000000000001mm" shape="rect" />
-      </footprint>}
-    />
-  )
-}
-export const useMyResistor = createUseComponent(MyResistor, pinLabels)"
-`)
+    "import { type ChipProps } from "tscircuit"
+    export const MyResistor = (props: ChipProps) => (
+      <chip
+        footprint={<footprint>
+            <smtpad portHints={["1","left"]} pcbX="-0.5mm" pcbY="0mm" width="0.6000000000000001mm" height="0.6000000000000001mm" shape="rect" />
+    <smtpad portHints={["2","right"]} pcbX="0.5mm" pcbY="0mm" width="0.6000000000000001mm" height="0.6000000000000001mm" shape="rect" />
+          </footprint>}
+        {...props}
+      />
+    )"
+  `)
 })

--- a/tests/test2-get-component-template.test.tsx
+++ b/tests/test2-get-component-template.test.tsx
@@ -1,19 +1,19 @@
 import { test, expect } from "bun:test"
 import { convertCircuitJsonToTscircuit } from "lib/index"
-import { Circuit } from "@tscircuit/core"
+import { readFile } from "node:fs/promises"
+import { join } from "node:path"
 import { getComponentUsingTemplate } from "lib/get-component-using-template"
 
 test("test2 getComponentUsingTemplate", async () => {
-  const circuit = new Circuit()
-
-  circuit.add(
-    <board width="10mm" height="10mm">
-      <resistor name="R1" resistance="1k" footprint="0402" />
-    </board>,
+  const circuitJson = JSON.parse(
+    await readFile(
+      join(__dirname, "../assets/input-circuit-json.json"),
+      "utf-8",
+    ),
   )
 
   const tscircuitCode = getComponentUsingTemplate({
-    circuitJson: circuit.getCircuitJson(),
+    circuitJson,
     componentName: "MyResistor",
     pinLabels: {
       pin1: ["pin1"],
@@ -25,49 +25,35 @@ test("test2 getComponentUsingTemplate", async () => {
   })
 
   expect(tscircuitCode).toMatchInlineSnapshot(`
-"import { createUseComponent } from "@tscircuit/core"
-import type { CommonLayoutProps } from "@tscircuit/props"
-const pinLabels = {
-  "pin1": [
-    "pin1"
-  ],
-  "pin2": [
-    "pin2"
-  ]
-} as const
-interface Props extends CommonLayoutProps {
-  name: string
-}
-export const MyResistor = (props: Props) => {
-  return (
-    <chip
-      {...props}
-      cadModel={{
-        objUrl: "...",
-        rotationOffset: { x: 0, y: 0, z: 0 },
-        positionOffset: { x: 0, y: 0, z: 0 },
-      }}
-      pinLabels={{
-  "pin1": [
-    "pin1"
-  ],
-  "pin2": [
-    "pin2"
-  ]
-}}
-      supplierPartNumbers={{
-  "jlcpcb": [
-    "123456"
-  ]
-}}
-      manufacturerPartNumber="123456"
-      footprint={<footprint>
-        <smtpad portHints={["1","left"]} pcbX="-0.5mm" pcbY="0mm" width="0.6000000000000001mm" height="0.6000000000000001mm" shape="rect" />
-<smtpad portHints={["2","right"]} pcbX="0.5mm" pcbY="0mm" width="0.6000000000000001mm" height="0.6000000000000001mm" shape="rect" />
-      </footprint>}
-    />
-  )
-}
-export const useMyResistor = createUseComponent(MyResistor, pinLabels)"
-`)
+    "import { type ChipProps } from "tscircuit"
+    const pinLabels = {
+      "pin1": [
+        "pin1"
+      ],
+      "pin2": [
+        "pin2"
+      ]
+    } as const
+    export const MyResistor = (props: ChipProps<typeof pinLabels>) => (
+      <chip
+        footprint={<footprint>
+            <smtpad portHints={["1","left"]} pcbX="-0.5mm" pcbY="0mm" width="0.6000000000000001mm" height="0.6000000000000001mm" shape="rect" />
+    <smtpad portHints={["2","right"]} pcbX="0.5mm" pcbY="0mm" width="0.6000000000000001mm" height="0.6000000000000001mm" shape="rect" />
+          </footprint>}
+        pinLabels={pinLabels}
+        cadModel={{
+            objUrl: "...",
+            rotationOffset: { x: 0, y: 0, z: 0 },
+            positionOffset: { x: 0, y: 0, z: 0 },
+          }}
+        supplierPartNumbers={{
+      "jlcpcb": [
+        "123456"
+      ]
+    }}
+        manufacturerPartNumber="123456"
+        {...props}
+      />
+    )"
+  `)
 })

--- a/tests/test3-kicad-mod-circuit-json-example.test.tsx
+++ b/tests/test3-kicad-mod-circuit-json-example.test.tsx
@@ -7,88 +7,79 @@ test("test3 kicad mod circuit json example", async () => {
   })
 
   expect(tscircuit).toMatchInlineSnapshot(`
-"import { createUseComponent } from "@tscircuit/core"
-import type { CommonLayoutProps } from "@tscircuit/props"
-const pinLabels = undefined as const
-interface Props extends CommonLayoutProps {
-  name: string
-}
-export const Test3Component = (props: Props) => {
-  return (
-    <chip
-      {...props}
-      footprint={<footprint>
-        <platedhole  portHints={["1"]} pcbX="-8.89mm" pcbY="7.62mm" outerDiameter="1.27mm" holeDiameter="0.7mm" shape="circle" />
-<platedhole  portHints={["2"]} pcbX="-8.89mm" pcbY="5.08mm" outerDiameter="1.27mm" holeDiameter="0.7mm" shape="circle" />
-<platedhole  portHints={["2"]} pcbX="-7.62mm" pcbY="5.08mm" outerDiameter="1.4mm" holeDiameter="0.85mm" shape="circle" />
-<platedhole  portHints={["3"]} pcbX="-8.89mm" pcbY="2.54mm" outerDiameter="1.27mm" holeDiameter="0.7mm" shape="circle" />
-<platedhole  portHints={["3"]} pcbX="-7.62mm" pcbY="2.54mm" outerDiameter="1.5mm" holeDiameter="0.85mm" shape="circle" />
-<platedhole  portHints={["4"]} pcbX="-8.89mm" pcbY="0mm" outerDiameter="1.27mm" holeDiameter="0.7mm" shape="circle" />
-<platedhole  portHints={["4"]} pcbX="-7.62mm" pcbY="0mm" outerDiameter="1.5mm" holeDiameter="0.85mm" shape="circle" />
-<platedhole  portHints={["5"]} pcbX="-8.89mm" pcbY="-2.54mm" outerDiameter="1.27mm" holeDiameter="0.7mm" shape="circle" />
-<platedhole  portHints={["5"]} pcbX="-7.62mm" pcbY="-2.54mm" outerDiameter="1.5mm" holeDiameter="0.85mm" shape="circle" />
-<platedhole  portHints={["6"]} pcbX="-8.89mm" pcbY="-5.08mm" outerDiameter="1.27mm" holeDiameter="0.7mm" shape="circle" />
-<platedhole  portHints={["6"]} pcbX="-7.62mm" pcbY="-5.08mm" outerDiameter="1.4mm" holeDiameter="0.85mm" shape="circle" />
-<platedhole  portHints={["7"]} pcbX="-8.89mm" pcbY="-7.62mm" outerDiameter="1.27mm" holeDiameter="0.7mm" shape="circle" />
-<platedhole  portHints={["7"]} pcbX="-7.62mm" pcbY="-7.62mm" outerDiameter="1.5mm" holeDiameter="0.85mm" shape="circle" />
-<platedhole  portHints={["8"]} pcbX="7.62mm" pcbY="-7.62mm" outerDiameter="1.524mm" holeDiameter="0.889mm" shape="circle" />
-<platedhole  portHints={["8"]} pcbX="8.89mm" pcbY="-7.62mm" outerDiameter="1.27mm" holeDiameter="0.7mm" shape="circle" />
-<platedhole  portHints={["9"]} pcbX="7.62mm" pcbY="-5.08mm" outerDiameter="1.4mm" holeDiameter="0.85mm" shape="circle" />
-<platedhole  portHints={["9"]} pcbX="8.89mm" pcbY="-5.08mm" outerDiameter="1.27mm" holeDiameter="0.7mm" shape="circle" />
-<platedhole  portHints={["10"]} pcbX="7.62mm" pcbY="-2.54mm" outerDiameter="1.5mm" holeDiameter="0.85mm" shape="circle" />
-<platedhole  portHints={["10"]} pcbX="8.89mm" pcbY="-2.54mm" outerDiameter="1.27mm" holeDiameter="0.7mm" shape="circle" />
-<platedhole  portHints={["11"]} pcbX="7.62mm" pcbY="0mm" outerDiameter="1.5mm" holeDiameter="0.85mm" shape="circle" />
-<platedhole  portHints={["11"]} pcbX="8.89mm" pcbY="0mm" outerDiameter="1.27mm" holeDiameter="0.7mm" shape="circle" />
-<platedhole  portHints={["12"]} pcbX="7.62mm" pcbY="2.54mm" outerDiameter="1.5mm" holeDiameter="0.85mm" shape="circle" />
-<platedhole  portHints={["12"]} pcbX="8.89mm" pcbY="2.54mm" outerDiameter="1.27mm" holeDiameter="0.7mm" shape="circle" />
-<platedhole  portHints={["13"]} pcbX="7.62mm" pcbY="5.08mm" outerDiameter="1.4mm" holeDiameter="0.85mm" shape="circle" />
-<platedhole  portHints={["13"]} pcbX="8.89mm" pcbY="5.08mm" outerDiameter="1.27mm" holeDiameter="0.7mm" shape="circle" />
-<platedhole  portHints={["14"]} pcbX="7.62mm" pcbY="7.62mm" outerDiameter="1.5mm" holeDiameter="0.85mm" shape="circle" />
-<platedhole  portHints={["14"]} pcbX="8.89mm" pcbY="7.62mm" outerDiameter="1.27mm" holeDiameter="0.7mm" shape="circle" />
-<smtpad portHints={["1"]} pcbX="-8.278mm" pcbY="7.62mm" width="1.626mm" height="1.325mm" shape="rect" />
-<smtpad portHints={["1"]} pcbX="-8.278mm" pcbY="7.62mm" width="1.626mm" height="1.325mm" shape="rect" />
-<smtpad portHints={["2"]} pcbX="-8.337mm" pcbY="5.08mm" width="1.626mm" height="1.208mm" shape="rect" />
-<smtpad portHints={["2"]} pcbX="-8.337mm" pcbY="5.08mm" width="1.626mm" height="1.208mm" shape="rect" />
-<smtpad portHints={["3"]} pcbX="-8.278mm" pcbY="2.54mm" width="1.626mm" height="1.325mm" shape="rect" />
-<smtpad portHints={["3"]} pcbX="-8.278mm" pcbY="2.54mm" width="1.626mm" height="1.325mm" shape="rect" />
-<smtpad portHints={["4"]} pcbX="-8.278mm" pcbY="0mm" width="1.626mm" height="1.325mm" shape="rect" />
-<smtpad portHints={["4"]} pcbX="-8.278mm" pcbY="0mm" width="1.626mm" height="1.325mm" shape="rect" />
-<smtpad portHints={["5"]} pcbX="-8.278mm" pcbY="-2.54mm" width="1.626mm" height="1.325mm" shape="rect" />
-<smtpad portHints={["5"]} pcbX="-8.278mm" pcbY="-2.54mm" width="1.626mm" height="1.325mm" shape="rect" />
-<smtpad portHints={["6"]} pcbX="-8.337mm" pcbY="-5.08mm" width="1.626mm" height="1.208mm" shape="rect" />
-<smtpad portHints={["6"]} pcbX="-8.337mm" pcbY="-5.08mm" width="1.626mm" height="1.208mm" shape="rect" />
-<smtpad portHints={["7"]} pcbX="-8.278mm" pcbY="-7.62mm" width="1.626mm" height="1.325mm" shape="rect" />
-<smtpad portHints={["7"]} pcbX="-8.278mm" pcbY="-7.62mm" width="1.626mm" height="1.325mm" shape="rect" />
-<smtpad portHints={["8"]} pcbX="8.278mm" pcbY="-7.62mm" width="1.626mm" height="1.325mm" shape="rect" />
-<smtpad portHints={["8"]} pcbX="8.278mm" pcbY="-7.62mm" width="1.626mm" height="1.325mm" shape="rect" />
-<smtpad portHints={["9"]} pcbX="8.337mm" pcbY="-5.08mm" width="1.626mm" height="1.208mm" shape="rect" />
-<smtpad portHints={["9"]} pcbX="8.337mm" pcbY="-5.08mm" width="1.626mm" height="1.208mm" shape="rect" />
-<smtpad portHints={["10"]} pcbX="8.278mm" pcbY="-2.54mm" width="1.626mm" height="1.325mm" shape="rect" />
-<smtpad portHints={["10"]} pcbX="8.278mm" pcbY="-2.54mm" width="1.626mm" height="1.325mm" shape="rect" />
-<smtpad portHints={["11"]} pcbX="8.278mm" pcbY="0mm" width="1.626mm" height="1.325mm" shape="rect" />
-<smtpad portHints={["11"]} pcbX="8.278mm" pcbY="0mm" width="1.626mm" height="1.325mm" shape="rect" />
-<smtpad portHints={["12"]} pcbX="8.278mm" pcbY="2.54mm" width="1.626mm" height="1.325mm" shape="rect" />
-<smtpad portHints={["12"]} pcbX="8.278mm" pcbY="2.54mm" width="1.626mm" height="1.325mm" shape="rect" />
-<smtpad portHints={["13"]} pcbX="8.337mm" pcbY="5.08mm" width="1.626mm" height="1.208mm" shape="rect" />
-<smtpad portHints={["13"]} pcbX="8.337mm" pcbY="5.08mm" width="1.626mm" height="1.208mm" shape="rect" />
-<smtpad portHints={["14"]} pcbX="8.278mm" pcbY="7.62mm" width="1.626mm" height="1.325mm" shape="rect" />
-<smtpad portHints={["14"]} pcbX="8.278mm" pcbY="7.62mm" width="1.626mm" height="1.325mm" shape="rect" />
-<silkscreenpath route={[{"x":-8.89,"y":-8.509},{"x":-8.89,"y":8.636}]} />
-<silkscreenpath route={[{"x":-6.985,"y":-10.414},{"x":6.985,"y":-10.414}]} />
-<silkscreenpath route={[{"x":6.985,"y":10.541},{"x":-6.985,"y":10.541}]} />
-<silkscreenpath route={[{"x":8.89,"y":-8.509},{"x":8.89,"y":8.636}]} />
-<silkscreenpath route={[{"x":-8.89,"y":8.636},{"x":-8.634777964987212,"y":9.588499698293818},{"x":-7.937499698293819,"y":10.285777964987211},{"x":-6.985,"y":10.541}]} />
-<silkscreenpath route={[{"x":-6.985,"y":-10.414},{"x":-7.937499698293818,"y":-10.158777964987209},{"x":-8.63477796498721,"y":-9.461499698293817},{"x":-8.89,"y":-8.509}]} />
-<silkscreenpath route={[{"x":6.985,"y":10.541},{"x":7.937499698293818,"y":10.285777964987211},{"x":8.63477796498721,"y":9.588499698293818},{"x":8.889999999999999,"y":8.636}]} />
-<silkscreenpath route={[{"x":8.89,"y":-8.509},{"x":8.63477796498721,"y":-9.461499698293817},{"x":7.937499698293818,"y":-10.158777964987209},{"x":6.985,"y":-10.413999999999998}]} />
-      </footprint>}
-    />
-  )
-}
-export const useTest3Component = createUseComponent(Test3Component, pinLabels)"
-`)
+    "import { type ChipProps } from "tscircuit"
+    export const Test3Component = (props: ChipProps) => (
+      <chip
+        footprint={<footprint>
+            <platedhole  portHints={["1"]} pcbX="-8.89mm" pcbY="7.62mm" outerDiameter="1.27mm" holeDiameter="0.7mm" shape="circle" />
+    <platedhole  portHints={["2"]} pcbX="-8.89mm" pcbY="5.08mm" outerDiameter="1.27mm" holeDiameter="0.7mm" shape="circle" />
+    <platedhole  portHints={["2"]} pcbX="-7.62mm" pcbY="5.08mm" outerDiameter="1.4mm" holeDiameter="0.85mm" shape="circle" />
+    <platedhole  portHints={["3"]} pcbX="-8.89mm" pcbY="2.54mm" outerDiameter="1.27mm" holeDiameter="0.7mm" shape="circle" />
+    <platedhole  portHints={["3"]} pcbX="-7.62mm" pcbY="2.54mm" outerDiameter="1.5mm" holeDiameter="0.85mm" shape="circle" />
+    <platedhole  portHints={["4"]} pcbX="-8.89mm" pcbY="0mm" outerDiameter="1.27mm" holeDiameter="0.7mm" shape="circle" />
+    <platedhole  portHints={["4"]} pcbX="-7.62mm" pcbY="0mm" outerDiameter="1.5mm" holeDiameter="0.85mm" shape="circle" />
+    <platedhole  portHints={["5"]} pcbX="-8.89mm" pcbY="-2.54mm" outerDiameter="1.27mm" holeDiameter="0.7mm" shape="circle" />
+    <platedhole  portHints={["5"]} pcbX="-7.62mm" pcbY="-2.54mm" outerDiameter="1.5mm" holeDiameter="0.85mm" shape="circle" />
+    <platedhole  portHints={["6"]} pcbX="-8.89mm" pcbY="-5.08mm" outerDiameter="1.27mm" holeDiameter="0.7mm" shape="circle" />
+    <platedhole  portHints={["6"]} pcbX="-7.62mm" pcbY="-5.08mm" outerDiameter="1.4mm" holeDiameter="0.85mm" shape="circle" />
+    <platedhole  portHints={["7"]} pcbX="-8.89mm" pcbY="-7.62mm" outerDiameter="1.27mm" holeDiameter="0.7mm" shape="circle" />
+    <platedhole  portHints={["7"]} pcbX="-7.62mm" pcbY="-7.62mm" outerDiameter="1.5mm" holeDiameter="0.85mm" shape="circle" />
+    <platedhole  portHints={["8"]} pcbX="7.62mm" pcbY="-7.62mm" outerDiameter="1.524mm" holeDiameter="0.889mm" shape="circle" />
+    <platedhole  portHints={["8"]} pcbX="8.89mm" pcbY="-7.62mm" outerDiameter="1.27mm" holeDiameter="0.7mm" shape="circle" />
+    <platedhole  portHints={["9"]} pcbX="7.62mm" pcbY="-5.08mm" outerDiameter="1.4mm" holeDiameter="0.85mm" shape="circle" />
+    <platedhole  portHints={["9"]} pcbX="8.89mm" pcbY="-5.08mm" outerDiameter="1.27mm" holeDiameter="0.7mm" shape="circle" />
+    <platedhole  portHints={["10"]} pcbX="7.62mm" pcbY="-2.54mm" outerDiameter="1.5mm" holeDiameter="0.85mm" shape="circle" />
+    <platedhole  portHints={["10"]} pcbX="8.89mm" pcbY="-2.54mm" outerDiameter="1.27mm" holeDiameter="0.7mm" shape="circle" />
+    <platedhole  portHints={["11"]} pcbX="7.62mm" pcbY="0mm" outerDiameter="1.5mm" holeDiameter="0.85mm" shape="circle" />
+    <platedhole  portHints={["11"]} pcbX="8.89mm" pcbY="0mm" outerDiameter="1.27mm" holeDiameter="0.7mm" shape="circle" />
+    <platedhole  portHints={["12"]} pcbX="7.62mm" pcbY="2.54mm" outerDiameter="1.5mm" holeDiameter="0.85mm" shape="circle" />
+    <platedhole  portHints={["12"]} pcbX="8.89mm" pcbY="2.54mm" outerDiameter="1.27mm" holeDiameter="0.7mm" shape="circle" />
+    <platedhole  portHints={["13"]} pcbX="7.62mm" pcbY="5.08mm" outerDiameter="1.4mm" holeDiameter="0.85mm" shape="circle" />
+    <platedhole  portHints={["13"]} pcbX="8.89mm" pcbY="5.08mm" outerDiameter="1.27mm" holeDiameter="0.7mm" shape="circle" />
+    <platedhole  portHints={["14"]} pcbX="7.62mm" pcbY="7.62mm" outerDiameter="1.5mm" holeDiameter="0.85mm" shape="circle" />
+    <platedhole  portHints={["14"]} pcbX="8.89mm" pcbY="7.62mm" outerDiameter="1.27mm" holeDiameter="0.7mm" shape="circle" />
+    <smtpad portHints={["1"]} pcbX="-8.278mm" pcbY="7.62mm" width="1.626mm" height="1.325mm" shape="rect" />
+    <smtpad portHints={["1"]} pcbX="-8.278mm" pcbY="7.62mm" width="1.626mm" height="1.325mm" shape="rect" />
+    <smtpad portHints={["2"]} pcbX="-8.337mm" pcbY="5.08mm" width="1.626mm" height="1.208mm" shape="rect" />
+    <smtpad portHints={["2"]} pcbX="-8.337mm" pcbY="5.08mm" width="1.626mm" height="1.208mm" shape="rect" />
+    <smtpad portHints={["3"]} pcbX="-8.278mm" pcbY="2.54mm" width="1.626mm" height="1.325mm" shape="rect" />
+    <smtpad portHints={["3"]} pcbX="-8.278mm" pcbY="2.54mm" width="1.626mm" height="1.325mm" shape="rect" />
+    <smtpad portHints={["4"]} pcbX="-8.278mm" pcbY="0mm" width="1.626mm" height="1.325mm" shape="rect" />
+    <smtpad portHints={["4"]} pcbX="-8.278mm" pcbY="0mm" width="1.626mm" height="1.325mm" shape="rect" />
+    <smtpad portHints={["5"]} pcbX="-8.278mm" pcbY="-2.54mm" width="1.626mm" height="1.325mm" shape="rect" />
+    <smtpad portHints={["5"]} pcbX="-8.278mm" pcbY="-2.54mm" width="1.626mm" height="1.325mm" shape="rect" />
+    <smtpad portHints={["6"]} pcbX="-8.337mm" pcbY="-5.08mm" width="1.626mm" height="1.208mm" shape="rect" />
+    <smtpad portHints={["6"]} pcbX="-8.337mm" pcbY="-5.08mm" width="1.626mm" height="1.208mm" shape="rect" />
+    <smtpad portHints={["7"]} pcbX="-8.278mm" pcbY="-7.62mm" width="1.626mm" height="1.325mm" shape="rect" />
+    <smtpad portHints={["7"]} pcbX="-8.278mm" pcbY="-7.62mm" width="1.626mm" height="1.325mm" shape="rect" />
+    <smtpad portHints={["8"]} pcbX="8.278mm" pcbY="-7.62mm" width="1.626mm" height="1.325mm" shape="rect" />
+    <smtpad portHints={["8"]} pcbX="8.278mm" pcbY="-7.62mm" width="1.626mm" height="1.325mm" shape="rect" />
+    <smtpad portHints={["9"]} pcbX="8.337mm" pcbY="-5.08mm" width="1.626mm" height="1.208mm" shape="rect" />
+    <smtpad portHints={["9"]} pcbX="8.337mm" pcbY="-5.08mm" width="1.626mm" height="1.208mm" shape="rect" />
+    <smtpad portHints={["10"]} pcbX="8.278mm" pcbY="-2.54mm" width="1.626mm" height="1.325mm" shape="rect" />
+    <smtpad portHints={["10"]} pcbX="8.278mm" pcbY="-2.54mm" width="1.626mm" height="1.325mm" shape="rect" />
+    <smtpad portHints={["11"]} pcbX="8.278mm" pcbY="0mm" width="1.626mm" height="1.325mm" shape="rect" />
+    <smtpad portHints={["11"]} pcbX="8.278mm" pcbY="0mm" width="1.626mm" height="1.325mm" shape="rect" />
+    <smtpad portHints={["12"]} pcbX="8.278mm" pcbY="2.54mm" width="1.626mm" height="1.325mm" shape="rect" />
+    <smtpad portHints={["12"]} pcbX="8.278mm" pcbY="2.54mm" width="1.626mm" height="1.325mm" shape="rect" />
+    <smtpad portHints={["13"]} pcbX="8.337mm" pcbY="5.08mm" width="1.626mm" height="1.208mm" shape="rect" />
+    <smtpad portHints={["13"]} pcbX="8.337mm" pcbY="5.08mm" width="1.626mm" height="1.208mm" shape="rect" />
+    <smtpad portHints={["14"]} pcbX="8.278mm" pcbY="7.62mm" width="1.626mm" height="1.325mm" shape="rect" />
+    <smtpad portHints={["14"]} pcbX="8.278mm" pcbY="7.62mm" width="1.626mm" height="1.325mm" shape="rect" />
+    <silkscreenpath route={[{"x":-8.89,"y":-8.509},{"x":-8.89,"y":8.636}]} />
+    <silkscreenpath route={[{"x":-6.985,"y":-10.414},{"x":6.985,"y":-10.414}]} />
+    <silkscreenpath route={[{"x":6.985,"y":10.541},{"x":-6.985,"y":10.541}]} />
+    <silkscreenpath route={[{"x":8.89,"y":-8.509},{"x":8.89,"y":8.636}]} />
+    <silkscreenpath route={[{"x":-8.89,"y":8.636},{"x":-8.634777964987212,"y":9.588499698293818},{"x":-7.937499698293819,"y":10.285777964987211},{"x":-6.985,"y":10.541}]} />
+    <silkscreenpath route={[{"x":-6.985,"y":-10.414},{"x":-7.937499698293818,"y":-10.158777964987209},{"x":-8.63477796498721,"y":-9.461499698293817},{"x":-8.89,"y":-8.509}]} />
+    <silkscreenpath route={[{"x":6.985,"y":10.541},{"x":7.937499698293818,"y":10.285777964987211},{"x":8.63477796498721,"y":9.588499698293818},{"x":8.889999999999999,"y":8.636}]} />
+    <silkscreenpath route={[{"x":8.89,"y":-8.509},{"x":8.63477796498721,"y":-9.461499698293817},{"x":7.937499698293818,"y":-10.158777964987209},{"x":6.985,"y":-10.413999999999998}]} />
+          </footprint>}
+        {...props}
+      />
+    )"
+  `)
 })
-
 const circuitJson: any = [
   {
     type: "source_component",


### PR DESCRIPTION
## Summary
- drop `createUseComponent` usage from generated component template
- generate components using `ChipProps` with pin label constants
- refresh test snapshots for new template output

## Testing
- `bun test tests`


------
https://chatgpt.com/codex/tasks/task_b_68bfbe6b2d7c832eb7955ea07a8850c3