### PR TITLE
feat: add courtyardrect element generation

### DIFF
--- a/lib/generate-footprint-tsx.tsx
+++ b/lib/generate-footprint-tsx.tsx
@@ -12,6 +12,7 @@ export const generateFootprintTsx = (
   const fabricationNotePaths = su(circuitJson).pcb_fabrication_note_path.list()
   const silkscreenTexts = su(circuitJson).pcb_silkscreen_text.list()
   const pcbCutouts = su(circuitJson).pcb_cutout.list()
+  const courtyardRects = su(circuitJson).pcb_courtyard_rect.list()
   const noteTexts = su(circuitJson).pcb_note_text.list()
   const noteRects = su(circuitJson).pcb_note_rect.list()
   const notePaths = su(circuitJson).pcb_note_path.list()
@@ -114,6 +115,19 @@ export const generateFootprintTsx = (
     } else {
       console.warn(`Unhandled pcb_cutout shape: ${(cutout as any).shape}`)
     }
+  }
+
+  // Add pcb_courtyard_rect elements
+  for (const courtyard of courtyardRects) {
+    const pcbX = courtyard.center.x
+    const pcbY = courtyard.center.y
+    const width = mmStr(courtyard.width)
+    const height = mmStr(courtyard.height)
+    const layer = courtyard.layer ?? "top"
+
+    elementStrings.push(
+      `<courtyardrect pcbX="${mmStr(pcbX)}" pcbY="${mmStr(pcbY)}" width="${width}" height="${height}" layer="${layer}" />`,
+    )
   }
 
   for (const noteText of noteTexts) {

--- a/tests/test7-support-courtyards.test.tsx
+++ b/tests/test7-support-courtyards.test.tsx
@@ -1,0 +1,95 @@
+import { expect, test } from "bun:test"
+import { convertCircuitJsonToTscircuit } from "lib"
+
+test("test7 support courtyards", async () => {
+  const tscircuit = convertCircuitJsonToTscircuit(circuitJson as any, {
+    componentName: "Test7Component",
+  })
+
+  expect(tscircuit).toMatchInlineSnapshot(`
+    "import { type ChipProps } from "tscircuit"
+    export const Test7Component = (props: ChipProps) => (
+      <chip
+        footprint={<footprint>
+            <smtpad portHints={["1"]} pcbX="-1mm" pcbY="0mm" width="0.6mm" height="0.8mm" shape="rect" />
+    <smtpad portHints={["2"]} pcbX="1mm" pcbY="0mm" width="0.6mm" height="0.8mm" shape="rect" />
+    <courtyardrect pcbX="0mm" pcbY="0mm" width="3mm" height="2mm" layer="top" />
+    <courtyardrect pcbX="0mm" pcbY="0mm" width="3.5mm" height="2.5mm" layer="bottom" />
+          </footprint>}
+        {...props}
+      />
+    )"
+  `)
+})
+
+const circuitJson = [
+  {
+    type: "source_component",
+    source_component_id: "generic_0",
+    supplier_part_numbers: {},
+  },
+  {
+    type: "schematic_component",
+    schematic_component_id: "schematic_generic_component_0",
+    source_component_id: "generic_0",
+    center: { x: 0, y: 0 },
+    rotation: 0,
+    size: { width: 0, height: 0 },
+  },
+  {
+    type: "pcb_component",
+    source_component_id: "generic_0",
+    pcb_component_id: "pcb_generic_component_0",
+    layer: "top",
+    center: { x: 0, y: 0 },
+    rotation: 0,
+    width: 1,
+    height: 1,
+  },
+  {
+    type: "pcb_smtpad",
+    pcb_smtpad_id: "pad1",
+    shape: "rect",
+    x: -1,
+    y: 0,
+    width: 0.6,
+    height: 0.8,
+    layer: "top",
+    pcb_component_id: "pcb_generic_component_0",
+    pcb_port_id: "port1",
+    port_hints: ["1"],
+  },
+  {
+    type: "pcb_smtpad",
+    pcb_smtpad_id: "pad2",
+    shape: "rect",
+    x: 1,
+    y: 0,
+    width: 0.6,
+    height: 0.8,
+    layer: "top",
+    pcb_component_id: "pcb_generic_component_0",
+    pcb_port_id: "port2",
+    port_hints: ["2"],
+  },
+  {
+    type: "pcb_courtyard_rect",
+    pcb_courtyard_rect_id: "courtyard1",
+    center: { x: 0, y: 0 },
+    width: 3,
+    height: 2,
+    layer: "top",
+    stroke_width: 0.1,
+    pcb_component_id: "pcb_generic_component_0",
+  },
+  {
+    type: "pcb_courtyard_rect",
+    pcb_courtyard_rect_id: "courtyard2",
+    center: { x: 0, y: 0 },
+    width: 3.5,
+    height: 2.5,
+    layer: "bottom",
+    stroke_width: 0.1,
+    pcb_component_id: "pcb_generic_component_0",
+  },
+]


### PR DESCRIPTION
## Summary
- generate <courtyardrect /> elements from pcb_courtyard_rect circuit JSON
- include position, dimensions, and layer metadata

## Testing
- bunx tsc --noEmit
- bun run format