### PR TITLE
feat: add pcb_courtyard_polygon and pcb_courtyard_circle to footprint TSX generation

### DIFF
--- a/lib/generate-footprint-tsx.tsx
+++ b/lib/generate-footprint-tsx.tsx
@@ -282,7 +282,8 @@ export const generateFootprintTsx = (
     elementStrings.push(`<courtyardrect ${attrs.join(" ")} />`)
   }
 
-  const courtyardPolygons = (su(circuitJson) as any).pcb_courtyard_polygon?.list() ?? []
+  const courtyardPolygons =
+    (su(circuitJson) as any).pcb_courtyard_polygon?.list() ?? []
   for (const courtyardPolygon of courtyardPolygons) {
     const courtyardPolygonAny = courtyardPolygon as any
     const attrs = [
@@ -308,7 +309,8 @@ export const generateFootprintTsx = (
     elementStrings.push(`<courtyardpolygon ${attrs.join(" ")} />`)
   }
 
-  const courtyardCircles = (su(circuitJson) as any).pcb_courtyard_circle?.list() ?? []
+  const courtyardCircles =
+    (su(circuitJson) as any).pcb_courtyard_circle?.list() ?? []
   for (const courtyardCircle of courtyardCircles) {
     const courtyardCircleAny = courtyardCircle as any
     const attrs = [

--- a/lib/generate-footprint-tsx.tsx
+++ b/lib/generate-footprint-tsx.tsx
@@ -282,6 +282,51 @@ export const generateFootprintTsx = (
     elementStrings.push(`<courtyardrect ${attrs.join(" ")} />`)
   }
 
+  const courtyardPolygons = (su(circuitJson) as any).pcb_courtyard_polygon?.list() ?? []
+  for (const courtyardPolygon of courtyardPolygons) {
+    const courtyardPolygonAny = courtyardPolygon as any
+    const attrs = [
+      `points={${JSON.stringify(courtyardPolygonAny.points ?? [])}}`,
+    ]
+
+    if (courtyardPolygonAny.stroke_width !== undefined) {
+      attrs.push(`strokeWidth={${courtyardPolygonAny.stroke_width}}`)
+    }
+    if (courtyardPolygonAny.is_filled !== undefined) {
+      attrs.push(`isFilled={${courtyardPolygonAny.is_filled}}`)
+    }
+    if (courtyardPolygonAny.has_stroke !== undefined) {
+      attrs.push(`hasStroke={${courtyardPolygonAny.has_stroke}}`)
+    }
+    if (courtyardPolygonAny.is_stroke_dashed !== undefined) {
+      attrs.push(`isStrokeDashed={${courtyardPolygonAny.is_stroke_dashed}}`)
+    }
+    if (courtyardPolygonAny.color !== undefined) {
+      attrs.push(`color="${courtyardPolygonAny.color}"`)
+    }
+
+    elementStrings.push(`<courtyardpolygon ${attrs.join(" ")} />`)
+  }
+
+  const courtyardCircles = (su(circuitJson) as any).pcb_courtyard_circle?.list() ?? []
+  for (const courtyardCircle of courtyardCircles) {
+    const courtyardCircleAny = courtyardCircle as any
+    const attrs = [
+      `pcbX={${courtyardCircleAny.center?.x ?? 0}}`,
+      `pcbY={${courtyardCircleAny.center?.y ?? 0}}`,
+      `radius={${courtyardCircleAny.radius ?? 0}}`,
+    ]
+
+    if (courtyardCircleAny.stroke_width !== undefined) {
+      attrs.push(`strokeWidth={${courtyardCircleAny.stroke_width}}`)
+    }
+    if (courtyardCircleAny.color !== undefined) {
+      attrs.push(`color="${courtyardCircleAny.color}"`)
+    }
+
+    elementStrings.push(`<courtyardcircle ${attrs.join(" ")} />`)
+  }
+
   if (elementStrings.length === 0) {
     return null
   }

--- a/tests/test8-support-courtyard.test.tsx
+++ b/tests/test8-support-courtyard.test.tsx
@@ -98,6 +98,76 @@ const projectCourtyardToFabricationNotes = (courtyardElements: any[]) => {
   return projected
 }
 
+test("test8 support courtyard polygon and circle", () => {
+  const tscircuit = convertCircuitJsonToTscircuit(circuitJson2, {
+    componentName: "Test8bComponent",
+  })
+
+  expect(tscircuit).toContain("<courtyardpolygon")
+  expect(tscircuit).toContain(`points={[{"x":-1,"y":-1},{"x":1,"y":-1},{"x":0,"y":1}]}`)
+  expect(tscircuit).toContain("<courtyardcircle")
+  expect(tscircuit).toContain("pcbX={2}")
+  expect(tscircuit).toContain("pcbY={1}")
+  expect(tscircuit).toContain("radius={0.8}")
+})
+
+const circuitJson2: any = [
+  {
+    type: "source_component",
+    source_component_id: "generic_1",
+    supplier_part_numbers: {},
+  },
+  {
+    type: "schematic_component",
+    schematic_component_id: "schematic_generic_component_1",
+    source_component_id: "generic_1",
+    center: { x: 0, y: 0 },
+    rotation: 0,
+    size: { width: 0, height: 0 },
+  },
+  {
+    type: "pcb_component",
+    source_component_id: "generic_1",
+    pcb_component_id: "pcb_generic_component_1",
+    layer: "top",
+    center: { x: 0, y: 0 },
+    rotation: 0,
+    width: 2,
+    height: 1,
+  },
+  {
+    type: "pcb_smtpad",
+    pcb_smtpad_id: "pcb_smtpad_1",
+    shape: "rect",
+    x: 0,
+    y: 0,
+    width: 0.5,
+    height: 0.5,
+    layer: "top",
+    pcb_component_id: "pcb_generic_component_1",
+    port_hints: ["1"],
+  },
+  {
+    type: "pcb_courtyard_polygon",
+    pcb_courtyard_polygon_id: "pcb_courtyard_polygon_0",
+    pcb_component_id: "pcb_generic_component_1",
+    layer: "top",
+    points: [
+      { x: -1, y: -1 },
+      { x: 1, y: -1 },
+      { x: 0, y: 1 },
+    ],
+  },
+  {
+    type: "pcb_courtyard_circle",
+    pcb_courtyard_circle_id: "pcb_courtyard_circle_0",
+    pcb_component_id: "pcb_generic_component_1",
+    layer: "top",
+    center: { x: 2, y: 1 },
+    radius: 0.8,
+  },
+]
+
 const circuitJson: any = [
   {
     type: "source_component",

--- a/tests/test8-support-courtyard.test.tsx
+++ b/tests/test8-support-courtyard.test.tsx
@@ -104,7 +104,9 @@ test("test8 support courtyard polygon and circle", () => {
   })
 
   expect(tscircuit).toContain("<courtyardpolygon")
-  expect(tscircuit).toContain(`points={[{"x":-1,"y":-1},{"x":1,"y":-1},{"x":0,"y":1}]}`)
+  expect(tscircuit).toContain(
+    `points={[{"x":-1,"y":-1},{"x":1,"y":-1},{"x":0,"y":1}]}`,
+  )
   expect(tscircuit).toContain("<courtyardcircle")
   expect(tscircuit).toContain("pcbX={2}")
   expect(tscircuit).toContain("pcbY={1}")


### PR DESCRIPTION
## Summary

Resolves tscircuit/tscircuit#1081 — "Make sure kicad component components create courtyards"

- Adds `<courtyardpolygon>` JSX output for `pcb_courtyard_polygon` circuit-json elements
- Adds `<courtyardcircle>` JSX output for `pcb_courtyard_circle` circuit-json elements
- Passes through optional attributes: `strokeWidth`, `isFilled`, `hasStroke`, `isStrokeDashed`, `color` for polygons; `strokeWidth`, `color` for circles

### Before

All 4 courtyard types are already produced by `kicad-component-converter` and rendered by `circuit-to-svg`, but only `pcb_courtyard_outline` and `pcb_courtyard_rect` were being converted to TSX footprint elements. Polygon and circle courtyard shapes were silently dropped.

### After

Full round-trip coverage for all 4 courtyard types:
| circuit-json type | TSX element |
|---|---|
| `pcb_courtyard_outline` | `<courtyardoutline>` (existing) |
| `pcb_courtyard_rect` | `<courtyardrect>` (existing) |
| `pcb_courtyard_polygon` | `<courtyardpolygon>` ✨ new |
| `pcb_courtyard_circle` | `<courtyardcircle>` ✨ new |

## Test plan

- [x] Added `test("test8 support courtyard polygon and circle")` verifying both new elements are emitted with correct attributes
- [x] All 12 pre-existing passing tests still pass

/claim #1081

🤖 Generated with [Claude Code](https://claude.com/claude-code)