### PR TITLE
fix: omit fontSize on silkscreentext when font_size is null

### DIFF
--- a/lib/generate-footprint-tsx.tsx
+++ b/lib/generate-footprint-tsx.tsx
@@ -84,14 +84,24 @@ export const generateFootprintTsx = (
     const pcbX = stext.anchor_position?.x ?? 0
     const pcbY = stext.anchor_position?.y ?? 0
     const anchorAlignment = stext.anchor_alignment
-    const fontSize = stext.font_size
     // Escape quotes in text content for JSX attribute
     const rawText = String(stext.text ?? "")
     const escapedText = rawText.replace(/"/g, '\\"')
 
-    elementStrings.push(
-      `<silkscreentext pcbX={${pcbX}} pcbY={${pcbY}} anchorAlignment="${anchorAlignment}" fontSize={${fontSize}} text="${escapedText}" />`,
-    )
+    // Only emit fontSize when set; emitting `fontSize={null}` or
+    // `fontSize={undefined}` produces invalid TSX that fails typecheck
+    // for downstream consumers of the generated component.
+    const attrs = [
+      `pcbX={${pcbX}}`,
+      `pcbY={${pcbY}}`,
+      `anchorAlignment="${anchorAlignment}"`,
+    ]
+    if (stext.font_size != null) {
+      attrs.push(`fontSize={${stext.font_size}}`)
+    }
+    attrs.push(`text="${escapedText}"`)
+
+    elementStrings.push(`<silkscreentext ${attrs.join(" ")} />`)
   }
 
   // Add cutout elements

--- a/tests/test4b-silkscreen-without-fontsize.test.tsx
+++ b/tests/test4b-silkscreen-without-fontsize.test.tsx
@@ -1,0 +1,61 @@
+import { test, expect } from "bun:test"
+import { convertCircuitJsonToTscircuit } from "lib"
+
+// Regression: when a pcb_silkscreen_text element has no font_size
+// (common in kicad_mod files that omit `(effects (font (size N N)))`),
+// the generator must NOT emit `fontSize={null}` / `fontSize={undefined}`
+// — the resulting TSX fails downstream typecheck because the
+// SilkscreenTextProps schema rejects null and undefined for fontSize.
+//
+// Expected behaviour: omit the fontSize attribute entirely so the
+// element renderer's default applies.
+test("test4b silkscreen text without font_size omits the prop", () => {
+  const tscircuit = convertCircuitJsonToTscircuit(circuitJson, {
+    componentName: "Test4bComponent",
+  })
+
+  expect(tscircuit).toContain("<silkscreentext")
+  expect(tscircuit).toContain('text="REF**"')
+  expect(tscircuit).not.toContain("fontSize={null}")
+  expect(tscircuit).not.toContain("fontSize={undefined}")
+})
+
+const circuitJson: any = [
+  {
+    type: "source_component",
+    source_component_id: "generic_0",
+    supplier_part_numbers: {},
+  },
+  {
+    type: "pcb_component",
+    source_component_id: "generic_0",
+    pcb_component_id: "pcb_generic_component_0",
+    layer: "top",
+    center: { x: 0, y: 0 },
+    rotation: 0,
+    width: 1.1,
+    height: 0.4,
+  },
+  {
+    type: "pcb_smtpad",
+    pcb_smtpad_id: "pcb_smtpad_0",
+    shape: "rect",
+    x: 0,
+    y: 0,
+    width: 0.5,
+    height: 0.5,
+    layer: "top",
+    pcb_component_id: "pcb_generic_component_0",
+    port_hints: ["1"],
+  },
+  // pcb_silkscreen_text WITHOUT font_size — mimics a kicad_mod that omits
+  // the (effects (font (size ...))) clause.
+  {
+    type: "pcb_silkscreen_text",
+    layer: "top",
+    pcb_component_id: "pcb_generic_component_0",
+    anchor_position: { x: 0, y: 1.05 },
+    anchor_alignment: "center",
+    text: "REF**",
+  },
+]


### PR DESCRIPTION
## Summary

`pcb_silkscreen_text` elements parsed from kicad_mod files often lack a `font_size` field (when the source omits the `(effects (font (size N N)))` clause). The generator was emitting `fontSize={null}` in that case, producing TSX that fails downstream typecheck because `SilkscreenTextProps.fontSize` rejects null/undefined.

```
components/footprints/Isp3080UxFootprint.tsx(174,70): error TS2322:
Type 'null' is not assignable to type 'string | number | undefined'.
```

## Fix

Build the `<silkscreentext>` attribute list conditionally — only include `fontSize=` when `stext.font_size != null`. When omitted, the renderer's default applies. Behavior when `font_size` IS set is unchanged (existing test4 snapshot still matches).

## Repro / motivation

Hit while running `tsci convert` on a 157-pad LGA InsightSiP `kicad_mod` from a community KiCad library. Every output file required hand-removing `fontSize={null}` from a single line before it would typecheck — same fix every time.

## Test plan

- [x] Existing test4 (silkscreen with font_size set) — snapshot unchanged ✓
- [x] New test4b (silkscreen without font_size) — asserts no `fontSize={null}` or `fontSize={undefined}` in output ✓
- [x] `bun test`: 16 / 16 pass
- [x] `bun run format:check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
