### PR TITLE
Add courtyard circle support

### DIFF
--- a/lib/generate-footprint-tsx.tsx
+++ b/lib/generate-footprint-tsx.tsx
@@ -19,6 +19,7 @@ export const generateFootprintTsx = (
   const noteDimensions = su(circuitJson).pcb_note_dimension.list()
   const courtyardOutlines = su(circuitJson).pcb_courtyard_outline.list()
   const courtyardRects = su(circuitJson).pcb_courtyard_rect.list()
+  const courtyardCircles = su(circuitJson).pcb_courtyard_circle.list()
 
   const elementStrings: string[] = []
 
@@ -265,6 +266,19 @@ export const generateFootprintTsx = (
     }
 
     elementStrings.push(`<courtyardrect ${attrs.join(" ")} />`)
+  }
+
+  for (const courtyardCircle of courtyardCircles) {
+    const attrs = [
+      `pcbX={${courtyardCircle.center?.x ?? 0}}`,
+      `pcbY={${courtyardCircle.center?.y ?? 0}}`,
+      `radius={${courtyardCircle.radius ?? 0}}`,
+    ]
+    if (courtyardCircle.layer !== undefined) {
+      attrs.push(`layer="${courtyardCircle.layer}"`)
+    }
+
+    elementStrings.push(`<courtyardcircle ${attrs.join(" ")} />`)
   }
 
   if (elementStrings.length === 0) {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@types/react": "18",
     "@types/react-dom": "18",
     "bun-match-svg": "^0.0.15",
-    "circuit-json": "^0.0.391",
+    "circuit-json": "^0.0.423",
     "circuit-to-svg": "^0.0.333",
     "commander": "^13.1.0",
     "tscircuit": "^0.0.1444",

--- a/tests/test8-support-courtyard.test.tsx
+++ b/tests/test8-support-courtyard.test.tsx
@@ -16,6 +16,7 @@ test("test8 support courtyard elements", async () => {
     <courtyardoutline outline={[{"x":-1.8,"y":-1.4},{"x":1.8,"y":-1.4},{"x":1.8,"y":1.4},{"x":-1.8,"y":1.4}]} layer="top" />
     <courtyardrect pcbX={0} pcbY={0} width={4} height={3} layer="top" />
     <courtyardrect pcbX={0.2} pcbY={0.2} width={4.6} height={3.6} layer="bottom" />
+    <courtyardcircle pcbX={0.4} pcbY={-0.3} radius={2.1} layer="top" />
           </footprint>}
         {...props}
       />
@@ -39,16 +40,23 @@ circuit.add(
   `)) as any[]
 
   const courtyardElements = renderedCircuitJson.filter((elm) =>
-    ["pcb_courtyard_outline", "pcb_courtyard_rect"].includes(elm.type),
+    [
+      "pcb_courtyard_outline",
+      "pcb_courtyard_rect",
+      "pcb_courtyard_circle",
+    ].includes(elm.type),
   )
 
-  expect(courtyardElements).toHaveLength(6)
+  expect(courtyardElements).toHaveLength(8)
   expect(
     courtyardElements.filter((elm) => elm.type === "pcb_courtyard_outline"),
   ).toHaveLength(2)
   expect(
     courtyardElements.filter((elm) => elm.type === "pcb_courtyard_rect"),
   ).toHaveLength(4)
+  expect(
+    courtyardElements.filter((elm) => elm.type === "pcb_courtyard_circle"),
+  ).toHaveLength(2)
 })
 
 const circuitJson: any = [
@@ -125,5 +133,13 @@ const circuitJson: any = [
     width: 4.6,
     height: 3.6,
     layer: "bottom",
+  },
+  {
+    type: "pcb_courtyard_circle",
+    pcb_courtyard_circle_id: "pcb_courtyard_circle_0",
+    pcb_component_id: "pcb_generic_component_0",
+    center: { x: 0.4, y: -0.3 },
+    radius: 2.1,
+    layer: "top",
   },
 ]


### PR DESCRIPTION
## Summary

Adds support for converting `pcb_courtyard_circle` circuit-json elements into `<courtyardcircle />` in generated tscircuit footprints.

## What Changed

- added `pcb_courtyard_circle` handling in `generateFootprintTsx`
- emitted `<courtyardcircle pcbX={...} pcbY={...} radius={...} layer="..." />`
- extended the courtyard round-trip test to cover circle support
- bumped `circuit-json` from `^0.0.391` to `^0.0.423` so the newer courtyard circle type/accessor is available

## Why

Courtyard outlines and rects were already supported, but courtyard circles were being skipped. This made the converter incomplete for footprints that use circular courtyard geometry.

## Impact

Footprints containing `pcb_courtyard_circle` now round-trip correctly from circuit-json to generated tscircuit code and back.

## Validation

- `bunx tsc --noEmit`
- `bun test`
