### PR TITLE
Support all PCB fabrication note elements in footprint conversion

### DIFF
--- a/lib/generate-footprint-tsx.tsx
+++ b/lib/generate-footprint-tsx.tsx
@@ -10,6 +10,10 @@ export const generateFootprintTsx = (
   const smtPads = su(circuitJson).pcb_smtpad.list()
   const silkscreenPaths = su(circuitJson).pcb_silkscreen_path.list()
   const fabricationNotePaths = su(circuitJson).pcb_fabrication_note_path.list()
+  const fabricationNoteTexts = su(circuitJson).pcb_fabrication_note_text.list()
+  const fabricationNoteRects = su(circuitJson).pcb_fabrication_note_rect.list()
+  const fabricationNoteDimensions =
+    su(circuitJson).pcb_fabrication_note_dimension.list()
   const silkscreenTexts = su(circuitJson).pcb_silkscreen_text.list()
   const pcbCutouts = su(circuitJson).pcb_cutout.list()
   const noteTexts = su(circuitJson).pcb_note_text.list()
@@ -75,8 +79,113 @@ export const generateFootprintTsx = (
     if ("color" in fabPath && fabPath.color !== undefined) {
       attrs.push(`color="${fabPath.color}"`)
     }
+    if ("layer" in fabPath && fabPath.layer === "bottom") {
+      attrs.push(`layer="bottom"`)
+    }
 
     elementStrings.push(`<fabricationnotepath ${attrs.join(" ")} />`)
+  }
+
+  for (const fabText of fabricationNoteTexts) {
+    const anchorPosition = fabText.anchor_position ?? { x: 0, y: 0 }
+    const anchorAlignment = fabText.anchor_alignment ?? "center"
+    const rawText = String(fabText.text ?? "")
+    const escapedText = rawText.replace(/"/g, '\\"')
+
+    const attrs = [
+      `pcbX={${anchorPosition.x}}`,
+      `pcbY={${anchorPosition.y}}`,
+      `anchorAlignment="${anchorAlignment}"`,
+      `text="${escapedText}"`,
+    ]
+
+    if (fabText.font !== undefined) {
+      attrs.push(`font="${fabText.font}"`)
+    }
+    if (fabText.font_size !== undefined) {
+      attrs.push(`fontSize={${fabText.font_size}}`)
+    }
+    if (fabText.color !== undefined) {
+      attrs.push(`color="${fabText.color}"`)
+    }
+    if (fabText.layer === "bottom") {
+      attrs.push(`layer="bottom"`)
+    }
+
+    elementStrings.push(`<fabricationnotetext ${attrs.join(" ")} />`)
+  }
+
+  for (const fabRect of fabricationNoteRects) {
+    const center = fabRect.center ?? { x: 0, y: 0 }
+    const attrs = [
+      `pcbX={${center.x}}`,
+      `pcbY={${center.y}}`,
+      `width={${fabRect.width ?? 0}}`,
+      `height={${fabRect.height ?? 0}}`,
+    ]
+
+    if (fabRect.stroke_width !== undefined) {
+      attrs.push(`strokeWidth={${fabRect.stroke_width}}`)
+    }
+    if (fabRect.is_filled !== undefined) {
+      attrs.push(`isFilled={${fabRect.is_filled}}`)
+    }
+    if (fabRect.has_stroke !== undefined) {
+      attrs.push(`hasStroke={${fabRect.has_stroke}}`)
+    }
+    if (fabRect.is_stroke_dashed !== undefined) {
+      attrs.push(`isStrokeDashed={${fabRect.is_stroke_dashed}}`)
+    }
+    if (fabRect.color !== undefined) {
+      attrs.push(`color="${fabRect.color}"`)
+    }
+    if ("corner_radius" in fabRect && fabRect.corner_radius !== undefined) {
+      attrs.push(`cornerRadius={${fabRect.corner_radius}}`)
+    }
+    if (fabRect.layer === "bottom") {
+      attrs.push(`layer="bottom"`)
+    }
+
+    elementStrings.push(`<fabricationnoterect ${attrs.join(" ")} />`)
+  }
+
+  for (const fabDimension of fabricationNoteDimensions) {
+    const fromPoint = fabDimension.from ?? { x: 0, y: 0 }
+    const toPoint = fabDimension.to ?? { x: 0, y: 0 }
+    const attrs = [
+      `from={{ x: ${fromPoint.x}, y: ${fromPoint.y} }}`,
+      `to={{ x: ${toPoint.x}, y: ${toPoint.y} }}`,
+    ]
+
+    if (fabDimension.text !== undefined) {
+      const escapedText = String(fabDimension.text).replace(/"/g, '\\"')
+      attrs.push(`text="${escapedText}"`)
+    }
+    if (fabDimension.font !== undefined) {
+      attrs.push(`font="${fabDimension.font}"`)
+    }
+    if (fabDimension.font_size !== undefined) {
+      attrs.push(`fontSize={${fabDimension.font_size}}`)
+    }
+    if (fabDimension.color !== undefined) {
+      attrs.push(`color="${fabDimension.color}"`)
+    }
+    if (fabDimension.arrow_size !== undefined) {
+      attrs.push(`arrowSize={${fabDimension.arrow_size}}`)
+    }
+    if (fabDimension.offset !== undefined) {
+      attrs.push(`offset={${fabDimension.offset}}`)
+    } else if (
+      "offset_distance" in fabDimension &&
+      fabDimension.offset_distance !== undefined
+    ) {
+      attrs.push(`offset={${fabDimension.offset_distance}}`)
+    }
+    if (fabDimension.layer === "bottom") {
+      attrs.push(`layer="bottom"`)
+    }
+
+    elementStrings.push(`<fabricationnotedimension ${attrs.join(" ")} />`)
   }
 
   // Add silkscreen text elements (use pcbX/pcbY instead of anchorPosition)

--- a/tests/test10-support-fabrication.test.tsx
+++ b/tests/test10-support-fabrication.test.tsx
@@ -1,0 +1,183 @@
+import { expect, test } from "bun:test"
+import { convertCircuitJsonToTscircuit } from "lib"
+import { runTscircuitCode } from "tscircuit"
+
+test("test10 support fabrication elements", async () => {
+  const tscircuit = convertCircuitJsonToTscircuit(circuitJson as any, {
+    componentName: "Test10Component",
+  })
+
+  expect(tscircuit).toMatchInlineSnapshot(`
+    "import { type ChipProps } from "tscircuit"
+    export const Test10Component = (props: ChipProps) => (
+      <chip
+        footprint={<footprint>
+            <fabricationnotepath route={[{"x":-1,"y":-1},{"x":1,"y":-1},{"x":1,"y":1}]} strokeWidth={0.15} color="#0000ff" layer="bottom" />
+    <fabricationnotetext pcbX={1} pcbY={2} anchorAlignment="top_left" text="Assembly" font="tscircuit2024" fontSize={1.5} color="#ff0000" />
+    <fabricationnoterect pcbX={0} pcbY={0} width={3.2} height={1.6} strokeWidth={0.2} isFilled={false} hasStroke={true} isStrokeDashed={true} color="#00ff00" cornerRadius={0.25} layer="bottom" />
+    <fabricationnotedimension from={{ x: -2, y: 0 }} to={{ x: 2, y: 0 }} text="4mm" font="tscircuit2024" fontSize={1.2} color="#654321" arrowSize={0.25} offset={0.5} layer="bottom" />
+          </footprint>}
+        {...props}
+      />
+    )"
+  `)
+
+  const renderedCircuitJson = (await runTscircuitCode(`
+${tscircuit}
+
+circuit.add(
+  <board width="20mm" height="20mm">
+    <Test10Component />
+  </board>,
+)
+  `)) as any[]
+
+  const fabricationElements = renderedCircuitJson.filter((elm) =>
+    elm.type.startsWith("pcb_fabrication_note_"),
+  )
+
+  expect(fabricationElements).toHaveLength(8)
+
+  const pathElements = fabricationElements.filter(
+    (elm) => elm.type === "pcb_fabrication_note_path",
+  )
+  const textElements = fabricationElements.filter(
+    (elm) => elm.type === "pcb_fabrication_note_text",
+  )
+  const rectElements = fabricationElements.filter(
+    (elm) => elm.type === "pcb_fabrication_note_rect",
+  )
+  const dimensionElements = fabricationElements.filter(
+    (elm) => elm.type === "pcb_fabrication_note_dimension",
+  )
+
+  expect(pathElements).toHaveLength(2)
+  expect(textElements).toHaveLength(2)
+  expect(rectElements).toHaveLength(2)
+  expect(dimensionElements).toHaveLength(2)
+
+  expect(pathElements[0]).toMatchObject({
+    layer: "bottom",
+    color: "#0000ff",
+    stroke_width: 0.15,
+  })
+  expect(pathElements[1]).toMatchObject({
+    layer: "bottom",
+    color: "#0000ff",
+    stroke_width: 0.15,
+  })
+  expect(textElements[0]).toMatchObject({
+    layer: "top",
+    text: "Assembly",
+    color: "#ff0000",
+  })
+  expect(textElements[1]).toMatchObject({
+    layer: "top",
+    text: "Assembly",
+    color: "#ff0000",
+  })
+  expect(rectElements[0]).toMatchObject({
+    layer: "bottom",
+    width: 3.2,
+    height: 1.6,
+    corner_radius: 0.25,
+  })
+  expect(rectElements[1]).toMatchObject({
+    layer: "bottom",
+    width: 3.2,
+    height: 1.6,
+    corner_radius: 0.25,
+  })
+  expect(dimensionElements[0]).toMatchObject({
+    layer: "bottom",
+    text: "4mm",
+    arrow_size: 0.25,
+    offset: 0.5,
+  })
+  expect(dimensionElements[1]).toMatchObject({
+    layer: "bottom",
+    text: "4mm",
+    arrow_size: 0.25,
+    offset: 0.5,
+  })
+}, 15000)
+
+const circuitJson = [
+  {
+    type: "source_component",
+    source_component_id: "generic_0",
+    supplier_part_numbers: {},
+  },
+  {
+    type: "schematic_component",
+    schematic_component_id: "schematic_generic_component_0",
+    source_component_id: "generic_0",
+    center: { x: 0, y: 0 },
+    rotation: 0,
+    size: { width: 0, height: 0 },
+  },
+  {
+    type: "pcb_component",
+    source_component_id: "generic_0",
+    pcb_component_id: "pcb_generic_component_0",
+    layer: "top",
+    center: { x: 0, y: 0 },
+    rotation: 0,
+    width: 1,
+    height: 1,
+  },
+  {
+    type: "pcb_fabrication_note_path",
+    pcb_fabrication_note_path_id: "pcb_fabrication_note_path_0",
+    pcb_component_id: "pcb_generic_component_0",
+    layer: "bottom",
+    route: [
+      { x: -1, y: -1 },
+      { x: 1, y: -1 },
+      { x: 1, y: 1 },
+    ],
+    stroke_width: 0.15,
+    color: "#0000ff",
+  },
+  {
+    type: "pcb_fabrication_note_text",
+    pcb_fabrication_note_text_id: "pcb_fabrication_note_text_0",
+    pcb_component_id: "pcb_generic_component_0",
+    layer: "top",
+    anchor_position: { x: 1, y: 2 },
+    anchor_alignment: "top_left",
+    font: "tscircuit2024",
+    font_size: 1.5,
+    text: "Assembly",
+    color: "#ff0000",
+  },
+  {
+    type: "pcb_fabrication_note_rect",
+    pcb_fabrication_note_rect_id: "pcb_fabrication_note_rect_0",
+    pcb_component_id: "pcb_generic_component_0",
+    layer: "bottom",
+    center: { x: 0, y: 0 },
+    width: 3.2,
+    height: 1.6,
+    stroke_width: 0.2,
+    corner_radius: 0.25,
+    is_filled: false,
+    has_stroke: true,
+    is_stroke_dashed: true,
+    color: "#00ff00",
+  },
+  {
+    type: "pcb_fabrication_note_dimension",
+    pcb_fabrication_note_dimension_id: "pcb_fabrication_note_dimension_0",
+    pcb_component_id: "pcb_generic_component_0",
+    layer: "bottom",
+    from: { x: -2, y: 0 },
+    to: { x: 2, y: 0 },
+    text: "4mm",
+    font: "tscircuit2024",
+    font_size: 1.2,
+    arrow_size: 0.25,
+    offset: 0.5,
+    color: "#654321",
+  },
+]

--- a/tests/test3-kicad-mod-circuit-json-example.test.tsx
+++ b/tests/test3-kicad-mod-circuit-json-example.test.tsx
@@ -74,6 +74,8 @@ test("test3 kicad mod circuit json example", async () => {
     <silkscreenpath route={[{"x":-6.985,"y":-10.414},{"x":-7.937499698293818,"y":-10.158777964987209},{"x":-8.63477796498721,"y":-9.461499698293817},{"x":-8.89,"y":-8.509}]} />
     <silkscreenpath route={[{"x":6.985,"y":10.541},{"x":7.937499698293818,"y":10.285777964987211},{"x":8.63477796498721,"y":9.588499698293818},{"x":8.889999999999999,"y":8.636}]} />
     <silkscreenpath route={[{"x":8.89,"y":-8.509},{"x":8.63477796498721,"y":-9.461499698293817},{"x":7.937499698293818,"y":-10.158777964987209},{"x":6.985,"y":-10.413999999999998}]} />
+    <fabricationnotetext pcbX={-8} pcbY={11.5} anchorAlignment="center" text="REF**" font="tscircuit2024" fontSize={1.27} />
+    <fabricationnotetext pcbX={0} pcbY={0} anchorAlignment="center" text="XIAO-Add-On" font="tscircuit2024" fontSize={1.27} />
           </footprint>}
         {...props}
       />


### PR DESCRIPTION
## Summary

This PR expands `circuit-json` -> `tscircuit` footprint generation to support the full PCB fabrication note family.

## Changes

- add support for `pcb_fabrication_note_text`
- add support for `pcb_fabrication_note_rect`
- add support for `pcb_fabrication_note_dimension`
- preserve additional fabrication path attributes like `layer` and `color`
- preserve fabrication rect attributes like `corner_radius`, stroke, fill, and dashed state
- preserve fabrication dimension attributes like `text`, `font`, `font_size`, `arrow_size`, `offset`, and `color`
- update the KiCad example snapshot to include generated fabrication text output
- add a regression test covering fabrication path/text/rect/dimension round-trip behavior