### PR TITLE
refactor: centralize optional footprint TSX attribute formatters

### DIFF
--- a/lib/generate-footprint-tsx/convert-copper-text.ts
+++ b/lib/generate-footprint-tsx/convert-copper-text.ts
@@ -1,6 +1,12 @@
 import { su } from "@tscircuit/soup-util"
 import type { FootprintElementConverter } from "./converter-types"
-import { escapeJsxText } from "./helpers"
+import {
+  escapeJsxText,
+  formatOptionalBooleanAttr,
+  formatOptionalNumberAttr,
+  formatOptionalStringAttr,
+  formatPcbRotationAttr,
+} from "./helpers"
 
 export const convertCopperText: FootprintElementConverter = (circuitJson) => {
   const copperTexts = su(circuitJson).pcb_copper_text.list()
@@ -8,33 +14,14 @@ export const convertCopperText: FootprintElementConverter = (circuitJson) => {
 
   for (const copperText of copperTexts) {
     const anchorPosition = copperText.anchor_position ?? { x: 0, y: 0 }
-    const attrs = [
-      `pcbX={${anchorPosition.x}}`,
-      `pcbY={${anchorPosition.y}}`,
-      `anchorAlignment="${copperText.anchor_alignment ?? "center"}"`,
-      `text="${escapeJsxText(copperText.text)}"`,
-    ]
+    const nonDefaultLayer =
+      copperText.layer !== undefined && copperText.layer !== "top"
+        ? formatOptionalStringAttr("layer", copperText.layer)
+        : ""
 
-    if (copperText.font !== undefined) {
-      attrs.push(`font="${copperText.font}"`)
-    }
-    if (copperText.font_size !== undefined) {
-      attrs.push(`fontSize={${copperText.font_size}}`)
-    }
-    if (copperText.ccw_rotation !== undefined) {
-      attrs.push(`pcbRotation="${copperText.ccw_rotation}deg"`)
-    }
-    if (copperText.is_knockout !== undefined) {
-      attrs.push(`knockout={${copperText.is_knockout}}`)
-    }
-    if (copperText.is_mirrored !== undefined) {
-      attrs.push(`mirrored={${copperText.is_mirrored}}`)
-    }
-    if (copperText.layer !== undefined && copperText.layer !== "top") {
-      attrs.push(`layer="${copperText.layer}"`)
-    }
-
-    elementStrings.push(`<coppertext ${attrs.join(" ")} />`)
+    elementStrings.push(
+      `<coppertext pcbX={${anchorPosition.x}} pcbY={${anchorPosition.y}} anchorAlignment="${copperText.anchor_alignment ?? "center"}" text="${escapeJsxText(copperText.text)}"${formatOptionalStringAttr("font", copperText.font)}${formatOptionalNumberAttr("fontSize", copperText.font_size)}${formatPcbRotationAttr(copperText.ccw_rotation)}${formatOptionalBooleanAttr("knockout", copperText.is_knockout)}${formatOptionalBooleanAttr("mirrored", copperText.is_mirrored)}${nonDefaultLayer} />`,
+    )
   }
 
   return elementStrings

--- a/lib/generate-footprint-tsx/convert-plated-holes.ts
+++ b/lib/generate-footprint-tsx/convert-plated-holes.ts
@@ -1,15 +1,7 @@
 import { su } from "@tscircuit/soup-util"
 import { mmStr } from "@tscircuit/mm"
 import type { FootprintElementConverter } from "./converter-types"
-import { formatPcbRotationAttr } from "./helpers"
-
-const formatOptionalMmAttr = (
-  attrName: string,
-  value: number | undefined,
-): string => {
-  if (value === undefined) return ""
-  return ` ${attrName}="${mmStr(value)}"`
-}
+import { formatOptionalMmAttr, formatPcbRotationAttr } from "./helpers"
 
 export const convertPlatedHoles: FootprintElementConverter = (circuitJson) => {
   const platedHoles = su(circuitJson).pcb_plated_hole.list()

--- a/lib/generate-footprint-tsx/helpers.ts
+++ b/lib/generate-footprint-tsx/helpers.ts
@@ -5,6 +5,38 @@ export const escapeJsxText = (value: unknown): string =>
 
 export const formatMm = (value: number | undefined): string => mmStr(value ?? 0)
 
+export const formatOptionalStringAttr = (
+  attrName: string,
+  value: string | undefined,
+): string => {
+  if (value === undefined) return ""
+  return ` ${attrName}="${escapeJsxText(value)}"`
+}
+
+export const formatOptionalNumberAttr = (
+  attrName: string,
+  value: number | undefined,
+): string => {
+  if (value === undefined) return ""
+  return ` ${attrName}={${value}}`
+}
+
+export const formatOptionalBooleanAttr = (
+  attrName: string,
+  value: boolean | undefined,
+): string => {
+  if (value === undefined) return ""
+  return ` ${attrName}={${value}}`
+}
+
+export const formatOptionalMmAttr = (
+  attrName: string,
+  value: number | undefined,
+): string => {
+  if (value === undefined) return ""
+  return ` ${attrName}="${mmStr(value)}"`
+}
+
 export const formatPcbRotationAttr = (
   rotation: string | number | undefined,
   attrName = "pcbRotation",
@@ -13,3 +45,12 @@ export const formatPcbRotationAttr = (
   const formatted = typeof rotation === "number" ? `${rotation}deg` : rotation
   return ` ${attrName}="${formatted}"`
 }
+
+export const formatSolderMaskAttrs = (options: {
+  is_covered_with_solder_mask?: boolean
+  soldermask_margin?: number
+}): string =>
+  `${formatOptionalBooleanAttr(
+    "coveredWithSolderMask",
+    options.is_covered_with_solder_mask,
+  )}${formatOptionalMmAttr("solderMaskMargin", options.soldermask_margin)}`


### PR DESCRIPTION
## Summary
- move optional JSX attribute formatting helpers into `lib/generate-footprint-tsx/helpers.ts`
- reuse the shared `formatOptionalMmAttr` in plated hole conversion
- reuse shared string/number/boolean/rotation helpers in copper text conversion
- add a shared solder mask formatter so upcoming converters do not recreate the same utils
