### PR TITLE
fix: preserve rect pcb_cutout rotation instead of emitting invalid pcbRotation="45mm"

### DIFF
--- a/lib/generate-footprint-tsx/convert-cutouts.ts
+++ b/lib/generate-footprint-tsx/convert-cutouts.ts
@@ -2,19 +2,60 @@ import { su } from "@tscircuit/soup-util"
 import type { FootprintElementConverter } from "./converter-types"
 import { formatMm } from "./helpers"
 
+const normalizeRotation = (rotation: number): number =>
+  ((rotation % 360) + 360) % 360
+
+const roundCoord = (value: number): number => Math.round(value * 1e4) / 1e4
+
+const getRotatedRectCorners = (
+  center: { x: number; y: number },
+  width: number,
+  height: number,
+  rotationDegrees: number,
+): Array<{ x: number; y: number }> => {
+  const radians = (rotationDegrees * Math.PI) / 180
+  const cos = Math.cos(radians)
+  const sin = Math.sin(radians)
+  const cornerOffsets = [
+    { x: -width / 2, y: -height / 2 },
+    { x: width / 2, y: -height / 2 },
+    { x: width / 2, y: height / 2 },
+    { x: -width / 2, y: height / 2 },
+  ]
+  return cornerOffsets.map((offset) => ({
+    x: roundCoord(center.x + offset.x * cos - offset.y * sin),
+    y: roundCoord(center.y + offset.x * sin + offset.y * cos),
+  }))
+}
+
 export const convertCutouts: FootprintElementConverter = (circuitJson) => {
   const pcbCutouts = su(circuitJson).pcb_cutout.list()
   const elementStrings: string[] = []
 
   for (const cutout of pcbCutouts) {
     if (cutout.shape === "rect") {
-      const rotation =
-        cutout.rotation !== undefined
-          ? ` pcbRotation="${formatMm(cutout.rotation)}"`
-          : ""
+      const rotation = normalizeRotation(cutout.rotation ?? 0)
+
+      if (rotation % 90 !== 0) {
+        // <cutout> has no rotation prop, so emit the rotated rect as a polygon
+        const points = getRotatedRectCorners(
+          cutout.center,
+          cutout.width,
+          cutout.height,
+          rotation,
+        )
+        elementStrings.push(
+          `<cutout shape="polygon" points={${JSON.stringify(points)}} />`,
+        )
+        continue
+      }
+
+      const isSideways = rotation === 90 || rotation === 270
+      const width = isSideways ? cutout.height : cutout.width
+      const height = isSideways ? cutout.width : cutout.height
 
       elementStrings.push(
-        `<cutout shape="rect" pcbX="${formatMm(cutout.center.x)}" pcbY="${formatMm(cutout.center.y)}" width="${formatMm(cutout.width)}" height="${formatMm(cutout.height)}"${rotation} />`,
+        `<cutout shape="rect" pcbX="${formatMm(cutout.center.x)}" pcbY="${formatMm(cutout.center.y)}" width="${formatMm(width)}" height="${formatMm(height)}" />`,
       )
     } else if (cutout.shape === "circle") {
       elementStrings.push(

--- a/tests/test5-pcb-cutout.test.tsx
+++ b/tests/test5-pcb-cutout.test.tsx
@@ -49,7 +49,7 @@ test("test pcb_cutout conversion - all shapes", async () => {
     export const ComponentWithCutouts = (props: ChipProps) => (
       <chip
         footprint={<footprint>
-            <cutout shape="rect" pcbX="0mm" pcbY="0mm" width="5mm" height="3mm" pcbRotation="45mm" />
+            <cutout shape="polygon" points={[{"x":-0.7071,"y":-2.8284},{"x":2.8284,"y":0.7071},{"x":0.7071,"y":2.8284},{"x":-2.8284,"y":-0.7071}]} />
     <cutout shape="circle" pcbX="10mm" pcbY="10mm" radius="2.5mm" />
     <cutout shape="polygon" points={[{"x":0,"y":0},{"x":5,"y":0},{"x":5,"y":5},{"x":0,"y":5}]} />
           </footprint>}
@@ -61,6 +61,72 @@ test("test pcb_cutout conversion - all shapes", async () => {
   const result = await runTscircuitCode(tscircuit)
   expect(Array.isArray(result)).toBe(true)
   expect(result).not.toHaveLength(0)
+}, 10000)
+
+test("test pcb_cutout conversion - rect rotation is preserved", async () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "pcb_cutout",
+      pcb_cutout_id: "cutout1",
+      shape: "rect",
+      center: { x: 0, y: 0 },
+      width: 5,
+      height: 3,
+      rotation: 45,
+    },
+    {
+      type: "pcb_cutout",
+      pcb_cutout_id: "cutout2",
+      shape: "rect",
+      center: { x: 10, y: 0 },
+      width: 4,
+      height: 2,
+      rotation: 90,
+    },
+  ]
+
+  const tscircuit = convertCircuitJsonToTscircuit(circuitJson, {
+    componentName: "ComponentWithRotatedCutouts",
+  })
+
+  expect(tscircuit).toMatchInlineSnapshot(`
+    "import { type ChipProps } from "tscircuit"
+    export const ComponentWithRotatedCutouts = (props: ChipProps) => (
+      <chip
+        footprint={<footprint>
+            <cutout shape="polygon" points={[{"x":-0.7071,"y":-2.8284},{"x":2.8284,"y":0.7071},{"x":0.7071,"y":2.8284},{"x":-2.8284,"y":-0.7071}]} />
+    <cutout shape="rect" pcbX="10mm" pcbY="0mm" width="2mm" height="4mm" />
+          </footprint>}
+        {...props}
+      />
+    )"
+  `)
+
+  const result = (await runTscircuitCode(tscircuit)) as AnyCircuitElement[]
+  const cutouts = result.filter((elm) => elm.type === "pcb_cutout")
+  expect(cutouts).toHaveLength(2)
+
+  const polygonCutout = cutouts.find(
+    (elm) => "shape" in elm && elm.shape === "polygon",
+  )
+  expect(polygonCutout).toMatchObject({
+    shape: "polygon",
+    points: [
+      { x: -0.7071, y: -2.8284 },
+      { x: 2.8284, y: 0.7071 },
+      { x: 0.7071, y: 2.8284 },
+      { x: -2.8284, y: -0.7071 },
+    ],
+  })
+
+  const rectCutout = cutouts.find(
+    (elm) => "shape" in elm && elm.shape === "rect",
+  )
+  expect(rectCutout).toMatchObject({
+    shape: "rect",
+    width: 2,
+    height: 4,
+  })
 }, 10000)
 
 test("test pcb_cutout conversion - rect without rotation", async () => {


### PR DESCRIPTION
## Summary

A rect `pcb_cutout` with `rotation` currently converts to `<cutout shape="rect" ... pcbRotation="45mm" />`, which is wrong in three ways:

1. The angle is formatted with `formatMm`, so degrees come out with a **mm** unit.
2. `<cutout>` doesn't accept `pcbRotation` at all — `RectCutoutProps` in `@tscircuit/props` explicitly omits it (checked latest `0.0.567`), so the generated code fails typechecking: `Property 'pcbRotation' does not exist on type 'RectCutoutProps'.`
3. At runtime the prop is stripped by zod, so the rotation is **silently dropped** — the board gets an axis-aligned cutout instead of the rotated one (`circuit-to-svg` renders `pcb_cutout.rotation`, so this is a physical difference).

Since `<cutout>` has no rotation prop today, this PR emits geometry that reproduces the input instead:

- rotation 0 / 180 → plain rect (unchanged output, no bogus attr)
- rotation 90 / 270 → `shape="rect"` with width/height swapped
- any other angle → `shape="polygon"` with the rect's rotated corners

If `<cutout>` gains a rotation prop in `@tscircuit/props`/core later, the converter can switch to emitting that instead.

## Input

```json
{
  "type": "pcb_cutout",
  "pcb_cutout_id": "cutout1",
  "shape": "rect",
  "center": { "x": 0, "y": 0 },
  "width": 5,
  "height": 3,
  "rotation": 45
}
```

## Before (wrong)

```tsx
<cutout shape="rect" pcbX="0mm" pcbY="0mm" width="5mm" height="3mm" pcbRotation="45mm" />
```

Round-trip (running the generated code back to circuit json): rebuilt `pcb_cutout` has **no rotation**.

## After

```tsx
<cutout shape="polygon" points={[{"x":-0.7071,"y":-2.8284},{"x":2.8284,"y":0.7071},{"x":0.7071,"y":2.8284},{"x":-2.8284,"y":-0.7071}]} />
```

Round-trip: rebuilt `pcb_cutout` is a polygon with exactly the 45°-rotated corners of the 5×3 rect — the physical cutout is preserved, and the generated code passes `tsc` cleanly.

## Testing

- Updated the `test5` snapshot that had the invalid `pcbRotation="45mm"` output locked in
- Added a test asserting the generated code and the rebuilt circuit json for 45° (polygon corners) and 90° (swapped rect)
- `bun test`: 27 pass, 0 fail
- `bunx tsc --noEmit`, `bun run format:check` (biome), `bun run build`: all clean

Fixes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)