### PR TITLE
fix: preserve pcb_hole solder mask props when converting to <hole>

### DIFF
--- a/lib/generate-footprint-tsx/convert-holes.ts
+++ b/lib/generate-footprint-tsx/convert-holes.ts
@@ -2,6 +2,7 @@ import { su } from "@tscircuit/soup-util"
 import { mmStr } from "@tscircuit/mm"
 import type { FootprintElementConverter } from "./converter-types"
 import { formatPcbRotationAttr } from "./footprint-tsx-attribute-formatters/format-pcb-rotation-attr"
+import { formatSolderMaskAttrs } from "./footprint-tsx-attribute-formatters/format-solder-mask-attrs"
 
 export const convertHoles: FootprintElementConverter = (circuitJson) => {
   const holes = su(circuitJson).pcb_hole.list()
@@ -10,22 +11,22 @@ export const convertHoles: FootprintElementConverter = (circuitJson) => {
   for (const hole of holes) {
     if (hole.hole_shape === "circle") {
       elementStrings.push(
-        `<hole pcbX="${mmStr(hole.x)}" pcbY="${mmStr(hole.y)}" diameter="${mmStr(hole.hole_diameter)}" />`,
+        `<hole pcbX="${mmStr(hole.x)}" pcbY="${mmStr(hole.y)}"${formatSolderMaskAttrs(hole)} diameter="${mmStr(hole.hole_diameter)}" />`,
       )
     } else if (hole.hole_shape === "rect") {
       elementStrings.push(
-        `<hole pcbX="${mmStr(hole.x)}" pcbY="${mmStr(hole.y)}" width="${mmStr(hole.hole_width)}" height="${mmStr(hole.hole_height)}" shape="rect" />`,
+        `<hole pcbX="${mmStr(hole.x)}" pcbY="${mmStr(hole.y)}"${formatSolderMaskAttrs(hole)} width="${mmStr(hole.hole_width)}" height="${mmStr(hole.hole_height)}" shape="rect" />`,
       )
     } else if (hole.hole_shape === "oval") {
       elementStrings.push(
-        `<hole pcbX="${mmStr(hole.x)}" pcbY="${mmStr(hole.y)}" width="${mmStr(hole.hole_width)}" height="${mmStr(hole.hole_height)}" shape="oval" />`,
+        `<hole pcbX="${mmStr(hole.x)}" pcbY="${mmStr(hole.y)}"${formatSolderMaskAttrs(hole)} width="${mmStr(hole.hole_width)}" height="${mmStr(hole.hole_height)}" shape="oval" />`,
       )
     } else if (
       hole.hole_shape === "pill" ||
       hole.hole_shape === "rotated_pill"
     ) {
       elementStrings.push(
-        `<hole pcbX="${mmStr(hole.x)}" pcbY="${mmStr(hole.y)}" width="${mmStr(hole.hole_width)}" height="${mmStr(hole.hole_height)}" shape="pill"${formatPcbRotationAttr("ccw_rotation" in hole ? hole.ccw_rotation : undefined)} />`,
+        `<hole pcbX="${mmStr(hole.x)}" pcbY="${mmStr(hole.y)}"${formatSolderMaskAttrs(hole)} width="${mmStr(hole.hole_width)}" height="${mmStr(hole.hole_height)}" shape="pill"${formatPcbRotationAttr("ccw_rotation" in hole ? hole.ccw_rotation : undefined)} />`,
       )
     }
   }

--- a/tests/test15-support-pcb-holes.test.tsx
+++ b/tests/test15-support-pcb-holes.test.tsx
@@ -1,4 +1,5 @@
 import { expect, test } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
 import { convertCircuitJsonToPcbSvg } from "circuit-to-svg"
 import { convertCircuitJsonToTscircuit } from "lib"
 import { runTscircuitCode } from "tscircuit"
@@ -37,6 +38,99 @@ circuit.add(
   const pcbSvg = convertCircuitJsonToPcbSvg(renderedCircuitJson)
   await expect(pcbSvg).toMatchSvgSnapshot(import.meta.path, "pcb")
 })
+
+test("test15 pcb holes preserve solder mask props", async () => {
+  const circuitJsonWithSolderMask: AnyCircuitElement[] = [
+    {
+      type: "pcb_hole",
+      pcb_hole_id: "hole_circle",
+      hole_shape: "circle",
+      x: -3,
+      y: -2.5,
+      hole_diameter: 0.8,
+      is_covered_with_solder_mask: true,
+      soldermask_margin: 0.2,
+    },
+    {
+      type: "pcb_hole",
+      pcb_hole_id: "hole_rect",
+      hole_shape: "rect",
+      x: -1,
+      y: 1.5,
+      hole_width: 1.2,
+      hole_height: 0.7,
+      is_covered_with_solder_mask: true,
+    },
+    {
+      type: "pcb_hole",
+      pcb_hole_id: "hole_oval",
+      hole_shape: "oval",
+      x: 0.2,
+      y: 0.4,
+      hole_width: 1.5,
+      hole_height: 0.75,
+      soldermask_margin: 0.15,
+    },
+    {
+      type: "pcb_hole",
+      pcb_hole_id: "hole_rotated_pill",
+      hole_shape: "rotated_pill",
+      x: 2.6,
+      y: 2,
+      hole_width: 1.8,
+      hole_height: 0.9,
+      ccw_rotation: 90,
+      is_covered_with_solder_mask: true,
+      soldermask_margin: 0.1,
+    },
+  ]
+
+  const tscircuit = convertCircuitJsonToTscircuit(circuitJsonWithSolderMask, {
+    componentName: "Test15SolderMaskComponent",
+  })
+
+  expect(tscircuit).toMatchInlineSnapshot(`
+    "import { type ChipProps } from "tscircuit"
+    export const Test15SolderMaskComponent = (props: ChipProps) => (
+      <chip
+        footprint={<footprint>
+            <hole pcbX="-3mm" pcbY="-2.5mm" coveredWithSolderMask={true} solderMaskMargin="0.2mm" diameter="0.8mm" />
+    <hole pcbX="-1mm" pcbY="1.5mm" coveredWithSolderMask={true} width="1.2mm" height="0.7mm" shape="rect" />
+    <hole pcbX="0.2mm" pcbY="0.4mm" solderMaskMargin="0.15mm" width="1.5mm" height="0.75mm" shape="oval" />
+    <hole pcbX="2.6mm" pcbY="2mm" coveredWithSolderMask={true} solderMaskMargin="0.1mm" width="1.8mm" height="0.9mm" shape="pill" pcbRotation="90deg" />
+          </footprint>}
+        {...props}
+      />
+    )"
+  `)
+
+  const rebuiltCircuitJson = (await runTscircuitCode(
+    tscircuit,
+  )) as AnyCircuitElement[]
+
+  const rebuiltHoles = rebuiltCircuitJson.filter(
+    (elm) => elm.type === "pcb_hole",
+  )
+  expect(rebuiltHoles).toHaveLength(4)
+
+  const holeAt = (x: number, y: number) =>
+    rebuiltHoles.find((elm) => "x" in elm && elm.x === x && elm.y === y)
+
+  expect(holeAt(-3, -2.5)).toMatchObject({
+    is_covered_with_solder_mask: true,
+    soldermask_margin: 0.2,
+  })
+  expect(holeAt(-1, 1.5)).toMatchObject({
+    is_covered_with_solder_mask: true,
+  })
+  expect(holeAt(0.2, 0.4)).toMatchObject({
+    soldermask_margin: 0.15,
+  })
+  expect(holeAt(2.6, 2)).toMatchObject({
+    is_covered_with_solder_mask: true,
+    soldermask_margin: 0.1,
+  })
+}, 10000)
 
 const circuitJson: any = [
   {


### PR DESCRIPTION
## Summary

`convertCircuitJsonToTscircuit` drops `is_covered_with_solder_mask` and `soldermask_margin` from **every** `pcb_hole` shape — the generated `<hole>` only carries position and size.

Both sides of the contract support these fields: circuit-json defines them on all `pcb_hole` shapes, and `@tscircuit/props` accepts `coveredWithSolderMask` / `solderMaskMargin` on all four `<hole>` shape variants. The repo even has a helper for exactly these two fields — `formatSolderMaskAttrs` in `footprint-tsx-attribute-formatters/format-solder-mask-attrs.ts` — which `convert-plated-holes.ts` uses everywhere, but `convert-holes.ts` never called it. This PR adds that helper call to all four hole branches.

(Rebased onto v0.0.41 after #61 moved the helpers from helpers.ts into footprint-tsx-attribute-formatters/)

## Input

```tsx
<hole shape="circle" diameter="1mm" coveredWithSolderMask solderMaskMargin="0.2mm" />
```

which produces circuit json with `"is_covered_with_solder_mask": true, "soldermask_margin": 0.2`.

## Before (wrong)

```tsx
<hole pcbX="0mm" pcbY="0mm" diameter="1mm" />
```

Round-trip (running the generated code back to circuit json): `is_covered_with_solder_mask` **flips from `true` to `false`** and `soldermask_margin` disappears — a hole designed to be tented under solder mask comes back as an open, exposed hole.

## After

```tsx
<hole pcbX="0mm" pcbY="0mm" coveredWithSolderMask={true} solderMaskMargin="0.2mm" diameter="1mm" />
```

Round-trip: rebuilt `pcb_hole` keeps `is_covered_with_solder_mask: true` and `soldermask_margin: 0.2`.

## Testing

- Added a test asserting the generated `<hole>` attributes for circle, rect, oval and rotated_pill shapes, plus round-trip assertions that the rebuilt circuit json preserves the fields
- `bun test`: 27 pass, 0 fail
- `bunx tsc --noEmit`, `bun run format:check` (biome), `bun run build`: all clean

Fixes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)