### PR TITLE
Add Vercel deployment config for the converter site

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "buildCommand": "bun run build:site",
+  "outputDirectory": "site-build",
+  "installCommand": "bun install"
+}


### PR DESCRIPTION
## Summary
- Adds `vercel.json` so the `site/` app (browser-based circuit-json-to-tscircuit converter, #73) can be deployed on Vercel with the correct build settings.
- Sets `buildCommand: bun run build:site`, `outputDirectory: site-build`, `installCommand: bun install`.
- No application code changes — deployment configuration only.

## Test plan
- [ ] Verify Vercel deploy picks up the config and builds the site successfully